### PR TITLE
ci: remove GitHub Pages deploy step

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -124,11 +124,3 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
         timeout-minutes: 10
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: public
-          user_name: St. Jude Cloud
-          user_email: support@stjude.cloud
-          commit_message: ${{ github.event.head_commit.message }}


### PR DESCRIPTION
Removes action due to missing manifest when viewing page