### PR TITLE
fix: Not requiring avatar_url to be present in GraphQL

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -157,7 +157,7 @@ exports.createSchemaCustomization = ({ actions, reporter }) => {
 
     type Contributor {
       login: String!
-      avatar_url: String!
+      avatar_url: String
       url: String!
       commits: Int
     }


### PR DESCRIPTION
This aims to fix https://github.com/stjudecloud/university/runs/3426704759?check_suite_focus=true

This was caused by a Contributor not having an avatar URL, however it's not a required field for our site to work so we can remove that requirement.

# TODO

- [X] ~Do we need a fallback image?~ - No, we aren't requiring it when we call it (`commit.committer?.avatar_url`) 