### PR TITLE
ci: adds mdl linting to PRs

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,13 @@
+name: Linting
+
+on: pull_request    
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Run mdl 
+        uses: actionshub/markdownlint@main
+        with:
+          path: docs


### PR DESCRIPTION
Adds automated linting to PRs to check the Markdown using `mdl`.